### PR TITLE
Remove obsolete "is-sorted" dependency

### DIFF
--- a/bootstrap/build.gradle.kts
+++ b/bootstrap/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
                 implementation(libs.kobweb.core)
                 implementation(libs.kobweb.silk.core)
                 implementation(libs.kobweb.silk.icons.fa)
-                implementation(npm("is-sorted", "1.0.5"))
                 implementation(npm("bootstrap", "5.3.1"))
             }
         }

--- a/bootstrap/src/jsMain/kotlin/com/stevdza/san/kotlinbs/IsSorted.kt
+++ b/bootstrap/src/jsMain/kotlin/com/stevdza/san/kotlinbs/IsSorted.kt
@@ -1,5 +1,0 @@
-package com.stevdza.san.kotlinbs
-
-@JsModule("is-sorted")
-@JsNonModule
-external fun <T> sorted(a: Array<T>): Boolean


### PR DESCRIPTION
This was likely done for debug purposes and should not be part of the bootstrap library.