### PR TITLE
Use the Gradle project version for the Bootstrap publish version

### DIFF
--- a/bootstrap/build.gradle.kts
+++ b/bootstrap/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.stevdza.san.bootstrap"
-version = "0.0.1"
+version = "0.0.8"
 
 kotlin {
     configAsKobwebLibrary(includeServer = false)
@@ -58,7 +58,7 @@ publishing {
             from(components["kotlin"])
             groupId = "com.github.stevdza-san"
             artifactId = "KotlinBootstrap"
-            version = "0.0.8"
+            version = version
         }
     }
 }


### PR DESCRIPTION
A Gradle project has its own version value. Probably best, for consistency /
general user expectation to just re-use it for the maven publish artifact.